### PR TITLE
Add support for new format in washington state

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,3 +4,4 @@ v0.2.0, 2015/03/09 -- New Source for formats.
 v0.2.1, 2015/08/25 -- Added format for Oregon
 v0.3.0, 2015/09/02 -- Included more possible formats.
 v0.3.1, 2015/12/03 -- Fixed West Virginia's format.
+v0.3.2, 2019/08/12 -- Add support for new format in Washington state.

--- a/dlnvalidation.py
+++ b/dlnvalidation.py
@@ -50,7 +50,9 @@ STATE_FORMATS = {
     'UT': r'^[0-9]{4,10}$',
     'VT': r'^[0-9]{8}$|^[0-9]{7}[a-z]$',
     'VA': r'^[a-z][0-9]{8}$|^[0-9]{9}$',
-    'WA': r'^[a-z*]{7}[0-9]{3}[0-9a-z]{2}$',
+    # Updated Washington state format according to the new format described
+    # here: https://www.wsiada.com/item/drivers-license-numbering-changes
+    'WA': r'^[a-z*]{7}[0-9]{3}[0-9a-z]{2}$|^wdl[0-9a-z]{9}$',
     'WV': r'^[0-9]{7}$|^[a-z]{1,2}[0-9]{5,6}$',
     'WI': r'^[a-z][0-9]{13}$',
     'WY': r'^[0-9]{9}$'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='DLNValidation',
-    version='0.3.1',
+    version='0.3.2',
     author='Mary Stufflebeam',
     author_email='mary@postmates.com',
     py_modules=['dlnvalidation'],

--- a/test_dlnvalidation.py
+++ b/test_dlnvalidation.py
@@ -407,11 +407,14 @@ class DLNValidationTest(unittest.TestCase):
         # Valid licenses New Format WA
         self.assertTrue(is_valid('WDL3P715863B', dl_state))
         self.assertTrue(is_valid('WDLABCD456DG', dl_state))
+        self.assertTrue(is_valid('wdl123456789', dl_state))
+        self.assertTrue(is_valid('wdlabcdefghi', dl_state))
 
         # Invalid Licenses
         self.assertFalse(is_valid('ab123', dl_state))
         self.assertFalse(is_valid('a123456', dl_state))
         self.assertFalse(is_valid('abcd123456789', dl_state))
+        self.assertFalse(is_valid('WDLABCD1234', dl_state))
 
     def test_west_virginia(self):
         dl_state = 'WV'
@@ -470,6 +473,7 @@ class DLNValidationTest(unittest.TestCase):
         self.assertTrue(is_valid(dl_num, "AS", True))
         self.assertTrue(is_valid(dl_num, "FM", True))
         self.assertTrue(is_valid(dl_num, "AA", True))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_dlnvalidation.py
+++ b/test_dlnvalidation.py
@@ -395,10 +395,20 @@ class DLNValidationTest(unittest.TestCase):
 
     def test_washington(self):
         dl_state = 'WA'
+        # Valid licenses Old Format WA
         self.assertTrue(is_valid('abcdefg12345', dl_state))
         self.assertTrue(is_valid('ab*****123ab', dl_state))
         self.assertTrue(is_valid('WASH*AB12345', dl_state))
         self.assertTrue(is_valid('ab*INGT1234b', dl_state))
+        self.assertTrue(is_valid('WHO**CL99095', dl_state))
+        self.assertTrue(is_valid('DOE**CL99095', dl_state))
+        self.assertTrue(is_valid('WOO**JT546KA', dl_state))
+
+        # Valid licenses New Format WA
+        self.assertTrue(is_valid('WDL3P715863B', dl_state))
+        self.assertTrue(is_valid('WDLABCD456DG', dl_state))
+
+        # Invalid Licenses
         self.assertFalse(is_valid('ab123', dl_state))
         self.assertFalse(is_valid('a123456', dl_state))
         self.assertFalse(is_valid('abcd123456789', dl_state))


### PR DESCRIPTION
Jira:
[WA state applicants unable to submit their Drivers License number](https://postmates.atlassian.net/browse/FLEET-17796)

We noticed a P0 bug when Anirban was signing up as an applicant in Washington state. As he entered his drivers license number (starting with WDL followed by 9 alpha-numeric digits), the landing page was not accepting his entry, saying 'Invalid Drivers License.'

After speaking with Tony, he mentioned that we are using an outdated Python package called DLNValidation. This was last updated in 2017, a year before the new driver's license requirements were established by WA state in 2018.